### PR TITLE
Move "sourceType" as needed by eslint v4

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,6 @@ import style from './rules/style';
 export default {
 	parser: require.resolve('babel-eslint'),
 	extends: 'eslint:recommended',
-	sourceType: 'module',
 	plugins: [
 		'compat',
 		'react',
@@ -20,6 +19,7 @@ export default {
 	},
 	parserOptions: {
 		ecmaVersion: 7,
+		sourceType: 'module',
 		ecmaFeatures: {
 			modules: true,
 			impliedStrict: true,


### PR DESCRIPTION
Per http://eslint.org/docs/user-guide/configuring#specifying-parser-options, "sourceType" should be put under "parserOptions" in v4.

Depends on #6.