### PR TITLE
Use react/jsx-tag-spacing instead of react/jsx-space-before-closing

### DIFF
--- a/src/rules/react.js
+++ b/src/rules/react.js
@@ -11,7 +11,7 @@ export default {
 	'react/jsx-no-target-blank': 2,		// avoids security vuln, see https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md
 	'react/jsx-no-undef': 2,
 	'react/jsx-pascal-case': 2,
-	'react/jsx-space-before-closing': 2,
+	'react/jsx-tag-spacing': [2, { beforeSelfClosing: 'always' }],
 	'react/jsx-uses-react': 2,
 	'react/jsx-uses-vars': 2,
 	'react/jsx-wrap-multilines': 2,


### PR DESCRIPTION
**The react/jsx-space-before-closing rule is deprecated. Please use the react/jsx-tag-spacing rule with the "beforeSelfClosing" option instead.**

https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-tag-spacing.md

I think we can simply use `react/jsx-tag-spacing: 2` as the default values are: 

```js
{
  "closingSlash": "never",
  "beforeSelfClosing": "always",
  "afterOpening": "never"
}
```