### PR TITLE
Use a hat range on `eslint-plugin-*` to avoid automatic bumping of major versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
   },
   "dependencies": {
     "babel-eslint": "^7.1.1",
-    "eslint-plugin-compat": ">=1",
-    "eslint-plugin-mocha": ">=2",
-    "eslint-plugin-react": ">=6"
+    "eslint-plugin-compat": "^1.0.0",
+    "eslint-plugin-mocha": "^4.0.0",
+    "eslint-plugin-react": "^7.0.0"
   },
   "devDependencies": {
     "eslint": "^4.4.1",


### PR DESCRIPTION
Resolves #16.

We probably shouldn't be pulling down major versions, so I just dropped the `>=` range on all dependency packages.